### PR TITLE
⚙️ Keep `accessor-pairs`

### DIFF
--- a/tests/linted/default/accessor-pairs.js
+++ b/tests/linted/default/accessor-pairs.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const alpha = {
+  sum: 0,
+
+  set sumValue (value) { // ❌ setWithoutGet:true of `accessor-pairs`
+    this.sum += value
+  }
+}
+
+class AccessorPairs {
+  constructor (value) {
+    this.savedValue = value
+  }
+
+  set value (value) { // ❌ setWithoutGet:true & enforceForClassMembers:true of `accessor-pairs`
+    this.savedValue = value
+  }
+}
+
+module.exports = {
+  alpha,
+  AccessorPairs,
+}


### PR DESCRIPTION
## Why

* See #35
