### PR TITLE
⚙️ Keep `prefer-numeric-literals`

### DIFF
--- a/tests/linted/default/prefer-numeric-literals.js
+++ b/tests/linted/default/prefer-numeric-literals.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const array = [
+  parseInt('111110111', 2), // ❌ `prefer-numeric-literals`
+  parseInt('767', 8), // ❌ `prefer-numeric-literals`
+  parseInt('1F7', 16), // ❌ `prefer-numeric-literals`
+
+  Number.parseInt('111110111', 2), // ❌ `prefer-numeric-literals`
+  Number.parseInt('767', 8), // ❌ `prefer-numeric-literals`
+  Number.parseInt('1F7', 16), // ❌ `prefer-numeric-literals`
+]
+
+module.exports = array


### PR DESCRIPTION
## Why

* See #178

