### PR TITLE
🐛 Clean up linted file for `space-before-blocks`

### DIFF
--- a/tests/linted/default/space-before-blocks.js
+++ b/tests/linted/default/space-before-blocks.js
@@ -25,21 +25,23 @@ for (let step = 0; step < 10; step += 1){ // ❌ keywords:always of `space-befor
   betaFunc()
 }
 
-// eslint-disable-next-line no-restricted-syntax
-let index = 0
-// eslint-disable-next-line no-restricted-syntax
-while (index < 10){ // ❌ keywords:always of `space-before-blocks`
-  betaFunc()
+{
+  // eslint-disable-next-line no-restricted-syntax
+  let index = 0
+  // eslint-disable-next-line no-restricted-syntax
+  while (index < 10){ // ❌ keywords:always of `space-before-blocks`
+    betaFunc()
 
-  index += 1
+    index += 1
+  }
+
+  // eslint-disable-next-line keyword-spacing, no-restricted-syntax
+  do{ // ✅ keywords:always of `space-before-blocks`
+    betaFunc()
+
+    index += 1
+  } while (index < 10)
 }
-
-// eslint-disable-next-line keyword-spacing, no-restricted-syntax
-do{ // ✅ keywords:always of `space-before-blocks`
-  betaFunc()
-
-  index += 1
-} while (index < 10)
 
 // eslint-disable-next-line keyword-spacing
 try{ // ✅ keywords:always of `space-before-blocks`


### PR DESCRIPTION
## Why

* See #294

## How

* Purge lints of `jest/require-hook`