### PR TITLE
🐛 Clean up linted file for `arrow-parens`

### DIFF
--- a/tests/linted/standard/arrow-parens.js
+++ b/tests/linted/standard/arrow-parens.js
@@ -14,13 +14,16 @@ const epsilonFunc = Promise.resolve()
 function zetaFunc (it) {
   return it
 }
-zetaFunc((it) => { // ❌ as-needed of `arrow-parens`
-  if (!it) {
-    return null
-  }
 
-  return 999
-})
+{
+  zetaFunc((it) => { // ❌ as-needed of `arrow-parens`
+    if (!it) {
+      return null
+    }
+
+    return 999
+  })
+}
 
 module.exports = {
   alphaFunc,


### PR DESCRIPTION
## Why

* See #300