### PR TITLE
🐛 Clean up linted file for `no-param-reassign`

### DIFF
--- a/tests/linted/standard/no-param-reassign.js
+++ b/tests/linted/standard/no-param-reassign.js
@@ -11,6 +11,7 @@ function betaFunc (it) {
 function gammaFunc (it) {
   const array = [1, 3, 5]
 
+  // eslint-disable-next-line no-restricted-syntax
   for (it in array) { // ❌ `no-param-reassign`
     // noop
   }
@@ -19,6 +20,7 @@ function gammaFunc (it) {
 function deltaFunc (it) {
   const array = [1, 3, 5]
 
+  // eslint-disable-next-line no-restricted-syntax
   for (it of array) { // ❌ `no-param-reassign`
     // noop
   }
@@ -39,6 +41,7 @@ function etaFunc (it) {
 function thetaFunc (it) {
   const array = [1, 3, 5]
 
+  // eslint-disable-next-line no-restricted-syntax
   for (it.first in array) { // ❌ `no-param-reassign`
     // noop
   }
@@ -47,6 +50,7 @@ function thetaFunc (it) {
 function iotaFunc (it) {
   const array = [1, 3, 5]
 
+  // eslint-disable-next-line no-restricted-syntax
   for (it.first of array) { // ❌ `no-param-reassign`
     // noop
   }


### PR DESCRIPTION
## Why

* See #314

## How

* Purge lints of `no-restricted-syntax`
