### PR TITLE
🐛 Clean up linted file of `no-restricted-syntax/noDoWhile`

### DIFF
--- a/tests/linted/standard/no-restricted-syntax/noDoWhile.js
+++ b/tests/linted/standard/no-restricted-syntax/noDoWhile.js
@@ -1,6 +1,7 @@
 'use strict'
 
 function noDoWhileFunc () {
+  // eslint-disable-next-line no-restricted-syntax
   let index = 0
 
   do { // ❌ { selector: 'DoWhileStatement' } of `no-restricted-syntax`


### PR DESCRIPTION
## Why

* See #317

## How

* Purge lints of `noLet` of `o-restricted-syntax`
