### PR TITLE
🐛 Clean up linted file for `no-restricted-syntax/noForIn`

### DIFF
--- a/tests/linted/standard/no-restricted-syntax/noForIn.js
+++ b/tests/linted/standard/no-restricted-syntax/noForIn.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function noForInFunc (array) {
-  let total = 0
+  let total = 0 // eslint-disable-line no-restricted-syntax
 
   for (const index in array) { // ❌ { selector: 'ForInStatement' } of `no-restricted-syntax`
     total += array[index]


### PR DESCRIPTION
## Why

* See #321

## How

* Purge lints of `no-restricted-syntax/noLet`
