### PR TITLE
🐛 Clean up linted file for `no-restricted-syntax/noForOf`

### DIFF
--- a/tests/linted/standard/no-restricted-syntax/noForOf.js
+++ b/tests/linted/standard/no-restricted-syntax/noForOf.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function noForOfFunc (array) {
-  let total = 0
+  let total = 0 // eslint-disable-line no-restricted-syntax
 
   for (const it of array) { // ❌ { selector: 'ForOfStatement' } of `no-restricted-syntax`
     total += it


### PR DESCRIPTION
## Why

* See #323

## How

* Purge lints of `no-restricted-syntax/noLet`
