### PR TITLE
🐛 Clean up linted file for `no-restricted-syntax/noWhile`

### DIFF
--- a/tests/linted/standard/no-restricted-syntax/noWhile.js
+++ b/tests/linted/standard/no-restricted-syntax/noWhile.js
@@ -1,8 +1,8 @@
 'use strict'
 
 function noWhileFunc (array) {
-  let total = 0
-  let index = 0
+  let total = 0 // eslint-disable-line no-restricted-syntax
+  let index = 0 // eslint-disable-line no-restricted-syntax
 
   while (index < array.length) { // ❌ { selector: 'WhileStatement' } of `no-restricted-syntax`
     total += array[index]


### PR DESCRIPTION
## Why

* See #325

## How

* Purge lints of `no-restricted-syntax/noLet`
