### PR TITLE
🐛 Clean up linted file for `operator-linebreak`

### DIFF
--- a/tests/linted/standard/operator-linebreak.js
+++ b/tests/linted/standard/operator-linebreak.js
@@ -4,6 +4,7 @@ const alpha = 1 + // ❌ before of `operator-linebreak`
   2
 
 function alphaFunc () {
+  // eslint-disable-next-line no-restricted-syntax
   let number = 0
 
   number


### PR DESCRIPTION
## Why

* See #333

