### PR TITLE
⚙️ Turn off `jsdoc/require-file-overview`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -516,7 +516,7 @@ rules:
       exemptedBy: []
       exemptNoArguments: false
   jsdoc/require-file-overview:
-    - error
+    - off # error
     - tags:
         file:
           initialCommentsOnly: true


### PR DESCRIPTION
## Why

* See #373 
