### PR TITLE
🐛 Remove `contexts` empty array from options if needed

### DIFF
--- a/.eslintrc.default.yml
+++ b/.eslintrc.default.yml
@@ -591,9 +591,10 @@ rules:
       # contexts: []
   jsdoc/require-yields:
     - error
-    - exemptedBy: []
+    - exemptedBy:
+        - inheritdoc
       forceRequireYields: false
-      contexts: []
+      # contexts: []
       withGeneratorTag: true
       next: false
       forceRequireNext: false

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -598,9 +598,10 @@ rules:
       # contexts: []
   jsdoc/require-yields:
     - error
-    - exemptedBy: []
+    - exemptedBy:
+        - inheritdoc
       forceRequireYields: false
-      contexts: []
+      # contexts: []
       withGeneratorTag: true
       next: false
       forceRequireNext: false


### PR DESCRIPTION
## Why

* See #379