### PR TITLE
⚙️ Keep `jsdoc/check-types`

### DIFF
--- a/tests/linted/default/jsdoc/check-types.js
+++ b/tests/linted/default/jsdoc/check-types.js
@@ -1,0 +1,99 @@
+'use strict'
+
+/* eslint-disable no-empty-function */
+
+/**
+ * Alpha function.
+ *
+ * @param {Number} first - First number. // ❌ `jsdoc/check-types`
+ */
+function alphaFunc (first) {
+
+}
+
+/**
+ * Beta function.
+ *
+ * @param {String} first - First number. // ❌ `jsdoc/check-types`
+ */
+function betaFunc (first) {
+
+}
+
+/**
+ * Gamma function.
+ *
+ * @param {Symbol} first - First number. // ❌ `jsdoc/check-types`
+ */
+function gammaFunc (first) {
+
+}
+
+/**
+ * Delta function.
+ *
+ * @param {Boolean} first - First number. // ❌ `jsdoc/check-types`
+ */
+function deltaFunc (first) {
+
+}
+
+/**
+ * Epsilon function.
+ *
+ * @param {BigInt} first - First number. // ❌ `jsdoc/check-types`
+ */
+function epsilonFunc (first) {
+
+}
+
+// for the reason Object → object
+// https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/check-types.md#why-not-capital-case-everything
+
+/**
+ * Zeta function.
+ *
+ * @param {Object} first - First number. // ❌ `jsdoc/check-types`
+ */
+function zetaFunc (first) {
+
+}
+
+/**
+ * Eta function.
+ *
+ * @returns {Number} - return number. // ❌ `jsdoc/check-types`
+ */
+function etaFunc () {
+  return 111
+}
+
+/**
+ * Theta function.
+ *
+ * @throws {String} - throw error. // ❌ `jsdoc/check-types`
+ */
+function thetaFunc () {
+
+}
+
+/**
+ * Iota function.
+ *
+ * @param {Array.<Number | String>} first - First number. // ❌ `jsdoc/check-types`
+ */
+function iotaFunc (first) {
+
+}
+
+module.exports = {
+  alphaFunc,
+  betaFunc,
+  gammaFunc,
+  deltaFunc,
+  epsilonFunc,
+  zetaFunc,
+  etaFunc,
+  thetaFunc,
+  iotaFunc,
+}


### PR DESCRIPTION
## Why

* See #390